### PR TITLE
sched/tune: we should not return a value from void function

### DIFF
--- a/kernel/sched/tune.c
+++ b/kernel/sched/tune.c
@@ -974,7 +974,7 @@ static void schedtune_boostgroup_init(struct schedtune *st, int idx) {
   boost_slots_init(st);
 #endif // CONFIG_DYNAMIC_STUNE_BOOST
 
-  return 0;
+  return;
 }
 
 static struct cgroup_subsys_state *


### PR DESCRIPTION
fixes "error: void function 'schedtune_boostgroup_init' should not return a value" when building with latest prebuild clang shipped with aosp